### PR TITLE
Styling Documentation

### DIFF
--- a/content/docs/styling.md
+++ b/content/docs/styling.md
@@ -1,0 +1,10 @@
++++
+title = "Styling"
+weight = 1
++++
+
+# Introduction
+
+Lorem Ipsum...
+
+

--- a/content/docs/styling.md
+++ b/content/docs/styling.md
@@ -5,6 +5,4 @@ weight = 1
 
 # Introduction
 
-Lorem Ipsum...
-
-
+`Iced` is a Rust GUI framework which targets a variety of platforms: `Web`, `Windows`, `MacOSX` and `Linux`. While each target has its own approach to rendering, the layout and styling model should be agnostic to the platform itself. `Iced`, being heavily influenced by the `Elm` language, incorporates many of the common patterns seen in HTML and CSS. This includes the declarative nature of HTML itself with the concept of `Element` and styling rules, some synonymous with CSS (e.g. `padding` and `background_color`). However, there are caveats. `CSS` is a standard that has evolved for over 24 years and it has adapted by making design decisions that are not necessarily consistent(I don't know how to say this nicely???). This page will discuss the `Iced` styling standard and how it differs from traditional `CSS`.  


### PR DESCRIPTION
Please don't immediately accept this merge request, I want this to be an open discussion. As promised [here](https://github.com/hecrj/iced/issues/772), I wanted to write a bit of documentation on the styling story that exists in `Iced` right now. I wrote a `styling.md` page with a primitive introduction. It's basically my understanding of how `Iced` came about and what it tries to do. Below are a few talking points I thought about putting into a section labeled `Differences between CSS and Iced Styling` (or something like that):

* In `CSS` every element can have padding, but in `iced` only some basic `widgets` have access to this property. This includes `Column`, `Row`, `Container`, et cetera.

* Right now some of the styling is kept in a `StyleSheet`, but not all styling rules. `padding` right now is set by a function call but I don't see anyway to define padding in the `StyleSheet` trait itself. Of course, there seems to be many `StyleSheet` traits, each one's definition unique to the `widget` itself. 

* Maybe we can talk about default values. Right now, there's an [open issue](https://github.com/hecrj/iced/issues/755) about the fact that `StyleSheet` trait objects don't have default implementations, but this might be fixed with a PR soon. I think default values are obviously useful and emphasizing that you can overide these default values, either in a custom widget or by passing a `StyleSheet` object to a widget you're already using, is important.

Please correct any mistakes or false statements I have made. I'm still learning the project as well. Also, feel free to add in stuff you'd like to see in the Styling doc.